### PR TITLE
Add installation instructions

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -144,8 +144,9 @@ apt-get install libapache2-mod-php5   # if wanted, but not required
     shared system. Also, we'll restart Apache later on, so there's no need to
     worry about it now if you're prompted.
 
-16. Remove the Apache sites-{available,enabled} directories, then copy over the
-    site configs from the repository and enable the 'default' site:
+16. Remove the contents of the Apache sites-{available,enabled} directories,
+    then copy over the site configs from the repository and enable the
+    'default' site:
 
 rm -f /etc/apache2/sites-{available,enabled}/*
 cp /dreamhack/setup/apache/sites/* /etc/apache2/sites-available/.


### PR DESCRIPTION
These installation instructions obsolete the README generated by backup/backup (which I'll modify in a later commit). These should be fully working (barring test suite failures, which I'm already opening bugs for), so if they don't, I'd like to hear about any problems.
