### PR TITLE
More anti-spam measures

### DIFF
--- a/www/do/apply
+++ b/www/do/apply
@@ -35,7 +35,7 @@ else {
     $error = 3;
   }
 
-  if (($error == 0) && (param("username") =~ /^LR.*\d{3}$/) && (param("notes") =~ /<a href=/)) {
+  if (($error == 0) && (param("username") =~ /^LR.*\d+$/) && (param("notes") =~ /<a href=/)) {
     # known spam
     $error = 3;
   }


### PR DESCRIPTION
More spambots are finding the application page. Things in common: They all use usernames following the syntax "LR[something]435", where "435" is a random selection of one or more digits, and they all include HTML links in their notes. Maybe I should disallow all HTML links, but we'll go with this for now.
