### PR TITLE
Disallow links entirely in the application form

### DIFF
--- a/www/do/apply
+++ b/www/do/apply
@@ -35,7 +35,7 @@ else {
     $error = 3;
   }
 
-  if (($error == 0) && (param("username") =~ /^LR.*\d+$/) && (param("notes") =~ /<a href=/)) {
+  if (($error == 0) && (param("notes") =~ /<a href=/)) {
     # known spam
     $error = 3;
   }


### PR DESCRIPTION
Turns out that it wasn't enough to just protect against the LR\* bots; now I'm
getting tons of spam from other bots too. Let's just disallow all HTML links
(or at least, those that follow the typical "&lt;a href=[...]&gt;" pattern).
