### PR TITLE
Fix bad check in setup process

### DIFF
--- a/sbin/dh-newuser
+++ b/sbin/dh-newuser
@@ -339,7 +339,7 @@ chown -R $UNIXUSER:$DHGROUP $UHOME
 echo setting rwx--x--x on home directory...
 chmod 711 $UHOME
 
-if [ "$COPYDHROOT" != "" ]; then
+if [ "$COPYDHROOT" == "1" ]; then
   echo copying and updating dhroot...
   # let's copy over the dhroot directory, update it, and use that instead of getting it from GitHub
   # NOTE: This won't work with anything other than the Daily Snapshot for now.


### PR DESCRIPTION
The COPYDHROOT variable was initially intended to be directly supplied on the command line (and would be either "" or "1"), but before commit was changed to be controlled by a switch instead. I forgot to update this line to match, which meant that any Dreamhack created in this time would have been set up incorrectly.

Fortunately only one Dreamhack appears to have been affected by this, and they've never logged in, so I'll be fixing their Dreamhack manually after submitting this pull request. Still, though... oops.
