### PR TITLE
Map remote branches to local branches

### DIFF
--- a/sbin/dh-newuser
+++ b/sbin/dh-newuser
@@ -363,6 +363,14 @@ else
     # we also want to sync up with the main branches
     git branch --set-upstream develop dreamwidth/develop 
     git branch --set-upstream master dreamwidth/master
+
+    # now map the other remote branches from our *own* repository to local branches
+    REMOTEBRANCHES=\$(git branch -a | perl -ne 'if (/^  remotes\\/origin\\/([^ ]+)$/) { print \$1 }')
+    for branch in \$REMOTEBRANCHES; do
+      if [[ \"\$branch\" != \"develop\" && \"\$branch\" != \"master\" ]]; then
+        git branch \"\$branch\" origin/\"\$branch\"
+      fi
+    done
   " $UNIXUSER
 
   if [ "$NONFREE" == "1" ]; then
@@ -376,6 +384,14 @@ else
       git fetch dreamwidth
       git branch --set-upstream develop dreamwidth/develop
       git branch --set-upstream master dreamwidth/master
+
+      # now map the other remote branches from our *own* repository to local branches
+      REMOTEBRANCHES=\$(git branch -a | perl -ne 'if (/^  remotes\\/origin\\/([^ ]+)$/) { print \$1 }')
+      for branch in \$REMOTEBRANCHES; do
+        if [[ \"\$branch\" != \"develop\" && \"\$branch\" != \"master\" ]]; then
+          git branch \"\$branch\" origin/\"\$branch\"
+        fi
+      done
     " $UNIXUSER
   fi
 fi


### PR DESCRIPTION
When creating a new user or reinstalling, map the remote branches on GitHub to local tracking branches automatically, except for "develop" and "master" (which remain tracked to dreamwidth). This allows people to jump straight back into working on a branch in progress without needing to worry about setting up their branches first.
