### PR TITLE
Leave /dreamhack/var/maintain.d/.placeholder alone

### DIFF
--- a/lib/bin/cron/maintain-dreamhacks
+++ b/lib/bin/cron/maintain-dreamhacks
@@ -27,6 +27,7 @@ my @files = readdir(DIR);
 closedir(DIR);
 
 foreach my $file (@files) {
+  next if ($file eq ".placeholder");   # it's okay to have this around, and it stops git from messing up permissions
   my $full = "$maintaindir/$file";
   next if (!(-f $full));
   my ($uid, $gid) = (stat($full))[4, 5];


### PR DESCRIPTION
For ages I've tried to work out why this file was mysteriously disappearing and subsequently causing git to delete the parent directory, messing up its permissions in the process. Turns out it was getting deleted by maintain-dreamhacks after it assumed it was a file to take action on.

This change tells maintain-dreamhacks to leave the file alone - not to take action on it and not to delete it.
