### PR TITLE
Allow dw-free-only Dreamhacks to be created

### DIFF
--- a/sbin/dh-newuser
+++ b/sbin/dh-newuser
@@ -60,6 +60,7 @@ while [[ "$1" =~ ^-- ]]; do
   elif [ "$1" == "--no-email" ];    then SENDEMAIL=0;
   elif [ "$1" == "--copy-dhroot" ]; then COPYDHROOT=1;
   elif [ "$1" == "--no-gh-check" ]; then GHCHECK=0;   # this is for the Daily Snapshot so we don't make needless GitHub checks
+  elif [ "$1" == "--no-nonfree" ];  then NONFREE=0;
   else
     echo "Switch '$1' not recognised"
     exit 1


### PR DESCRIPTION
Add a new --no-nonfree switch to dh-newuser to stop dw-nonfree from being cloned and used. (The functionality for this is already in dh-newuser; this merely allows it to be set via a switch.)

(I am finally able to work properly with GitHub again properly now, since I've finally upgraded my browser to something more recent. I wasn't able to submit pull requests before, which is why I haven't been doing much on the code.)