### PR TITLE
Remove redundancy in sbin/find-old-apaches

### DIFF
--- a/sbin/find-old-apaches
+++ b/sbin/find-old-apaches
@@ -1,12 +1,7 @@
 #!/bin/bash
 DAYS=${1-"7"}
 echo "Apaches where the owners haven't logged in within the last $DAYS days:"
-LOGGEDIN=`ps -A -o user:16,command | awk '/^dh-[^ ]+ +-bash$/ { print $1 }'`
-
-lastlog -b $DAYS | awk '/^dh-/ { sub(/^dh-/, ""); print $1 }' | xargs /dreamhack/lib/bin/get-apaches | xargs -i cat {}/etc/httpd.pid 2>/dev/null | xargs ps p
-#lastlog -b $DAYS | awk '/^dh-/ { print $1 }'
 ELIGIBLE=$(grep -vxF -f <(ps -A -o user:16,command | awk '/^dh-[^ ]+ +-bash$/ { print $1 }') <(lastlog -b $DAYS | awk '/^dh-/ { print $1 }') | sed 's/^dh-//')
-echo $ELIGIBLE
 
 xargs /dreamhack/lib/bin/get-apaches <<IN | xargs -i cat {}/etc/httpd.pid 2>/dev/null | xargs ps p
 $ELIGIBLE


### PR DESCRIPTION
/sbin/find-old-apaches is a script designed to find running Apaches owned by users who have not logged in in the past <x> days (where <x> is a number supplied on the command line; 7 by default). It had a number of redundant commands causing output to be confusing; this cleans up the redundant commands.