### PR TITLE
Update the maintainers page and remove the age

### DIFF
--- a/www/maintainers.shtml
+++ b/www/maintainers.shtml
@@ -6,10 +6,10 @@
           also be found on <a href="http://wiki.dwscoalition.org/notes/IRC">the Dreamwidth IRC
           channel</a> under the name "Sophira".</p>
 
-          <p>Sophie is a 31-year-old Perl coder, and she used to maintain a similar, privately-run
-          service for Goathacks (ready-to-go LiveJournal installs) after the original service died.
-          She's really pumped about Dreamwidth, and wants to do her part to help Dreamwidth become
-          really good.</p>
+          <p>As a Perl coder amd systems administrator, Sophie used to maintain a similar,
+          privately-run service for Goathacks (ready-to-go LiveJournal installs) after the original
+          Goathack service died. She's really pumped about Dreamwidth, and wants to do her part to
+          help Dreamwidth become really good.</p>
 
           <p>This server is graciously provided by Dreamwidth Studios, LLC for the use of the
           Dreamhack service. Thank you!</p>


### PR DESCRIPTION
There's probably little point in having the age here, and it needs an update every year or it gets out of date, as is the case here. Instead, I've rewritten it a little.