### PR TITLE
GitHub codetour loop changes

### DIFF
--- a/lib/bin/codetour.py
+++ b/lib/bin/codetour.py
@@ -23,7 +23,6 @@ def fetch_from_repo(repo, since):
         old_req = req
 
         if "link" in req.headers:
-            print req.headers["link"]
             for link in req.headers["link"].split(","):
                 match = re.search('<([^>]+)>; rel="next"', link)
                 if match:

--- a/www/dev/codetour/index.cgi
+++ b/www/dev/codetour/index.cgi
@@ -16,7 +16,7 @@ my $fromdate = param("fromdate");
 my $todate = param("todate");
 
 my $git = '/usr/bin/git --git-dir="/dreamhack/opt/dhroot/.git" --work-tree="/dreamhack/opt/dhroot"';
-my $refreshdate = `$git show -s --pretty=format:"%ci" develop`;
+my ($refreshcommit, $refreshdate) = split(/,/, `$git show -s --pretty=format:"%H,%ci" develop`);
 my $codetourrev = `$git rev-parse code-tour`;
 my @revs = split(/\n/, `$git log --first-parent --pretty=format:"%H" $codetourrev^..develop`);
 # check to see that $codetourrev is the last rev in @revs; if not, that means the 'code-tour' tag isn't on a 'develop' merge and things might be a bit weird.
@@ -84,7 +84,7 @@ if (!defined $dates) {
 </div>
 <p><input type="submit" value="Generate"></p>
 </form>
-<p><small>The default value of the 'from' date is determined by the '<b>code-tour</b>' tag in the local dw-free repository, which is refreshed weekly; it was last refreshed at $refreshdate</b>.</small></p>
+<p><small>The default value of the 'from' date is determined by the '<b>code-tour</b>' tag in the local dw-free repository, which is refreshed weekly; the date of the last commit on 'develop' according to this repository is <a href="https://github.com/dreamwidth/dw-free/commit/$refreshcommit">$refreshdate</a>.</small></p>
 <p>This script uses <span style='white-space: nowrap;'><a href='http://afuna.dreamwidth.org/profile'><img src='http://s.dreamwidth.org/img/silk/identity/user.png' alt='[personal profile] ' width='17' height='17' style='vertical-align: text-bottom; border: 0; padding-right: 1px;' /></a><a href='http://afuna.dreamwidth.org/'><b>afuna</b></a></span>'s code tour generator, programmed in Python.</p>
 </body>
 </html>

--- a/www/dev/codetour/index.cgi
+++ b/www/dev/codetour/index.cgi
@@ -77,7 +77,7 @@ if (!defined $dates) {
 <h1>Code Tour Generator</h1>
 <form method="get" action="index.cgi">
 <p>What dates should the code tour cover?</p>
-<input type="radio" name="dates" value="fromlasttonow" id="dates-fromlasttonow" checked="true"> <label for="dates-fromlasttonow">From the end of the last code tour (according to the repository: $codetourdate) to now</label><br>$warning
+<input type="radio" name="dates" value="fromlasttonow" id="dates-fromlasttonow" checked="true"> <label for="dates-fromlasttonow">From the date of the last code tour (according to the repository: $codetourdate) to now</label><br>$warning
 <input type="radio" name="dates" value="custom" id="dates-custom"> <label for="dates-custom">Between these dates:<br><small>(YYYY-MM-DD format, please; click text boxes for date pickers; end date is optional and can be left blank if you don't want an end date.)</small></label><br>
 <div id="customDates">
 <input type="text" class="date" name="fromdate" id="popupDatePickerFrom" value="$codetourdate"> to <input type="text" class="date" name="todate" placeholder="Now" id="popupDatePickerTo">
@@ -135,7 +135,7 @@ else {
 <body>
 <h2>Resolved issues from $fromdate to $dtodate</h2>
 <hr>
-<p>Copy and paste the following into a text editor, and then use <a href="http://wiki.dwscoalition.org/notes/How_to_do_a_Code_Tour">the wiki guide</a> to make the code tour. The 'category' field on each issue is set to the milestone if there is one, but for the vast majority this will not be filled in - please edit it if this is the case!</p>
+<p>Copy and paste the following into a text editor, and then use <a href="http://wiki.dwscoalition.org/notes/How_to_do_a_Code_Tour">the wiki guide</a> to make the code tour. There may be duplicates between this code tour and the last one near the top; you may need to remove them manually. The 'category' field on each issue is set to the milestone if there is one, but for the vast majority this will not be filled in - please edit it if this is the case!</p>
 <textarea rows="20" cols="120">$doutput</textarea>
 <p>After you're done editing in your external text editor, <a href="http://www.dreamwidth.org/update?usejournal=dw_dev">open a window to post it in dw_dev</a>.</p>
 </body>
@@ -212,7 +212,7 @@ sub error {
 <p><b>$msg</b></p>
 <form method="get" action="index.cgi">
 <p>What dates should the code tour cover?</p>
-<input type="radio" name="dates" value="fromlasttonow" id="dates-fromlasttonow" checked="true"> <label for="dates-fromlasttonow">From the end of the last code tour (according to the repository: $codetourdate) to now</label><br>$warning
+<input type="radio" name="dates" value="fromlasttonow" id="dates-fromlasttonow" checked="true"> <label for="dates-fromlasttonow">From the date of the last code tour (according to the repository: $codetourdate) to now</label><br>$warning
 <input type="radio" name="dates" value="custom" id="dates-custom"> <label for="dates-custom">Between these dates:<br><small>(YYYY-MM-DD format, please; click text boxes for date pickers; end date is optional and can be left blank if you don't want an end date.)</small></label><br>
 <div id="customDates">
 <input type="text" class="date" name="fromdate" id="popupDatePickerFrom" value="$codetourdate"> to <input type="text" class="date" name="todate" placeholder="Now" id="popupDatePickerTo">


### PR DESCRIPTION
Merge the latest changes from Afuna's gist. It should now loop properly, rather than just getting two pages.

As before, this can be viewed on the dev-hack machine at http://dev-hack.dreamwidth.net/dev/codetour/ .