### PR TITLE
Check both repos instead of just dw-nonfree

### DIFF
--- a/lib/bin/check-github-account
+++ b/lib/bin/check-github-account
@@ -25,7 +25,7 @@ print STDERR "GitHub user '$canon' found, checking repos...\n";
 my @repos = qw(dw-free dw-nonfree);
 foreach my $repo (@repos) {
   print STDERR "$canon/$repo... ";
-  my $repoout = get("https://api.github.com/repos/$canon/dw-free");
+  my $repoout = get("https://api.github.com/repos/$canon/$repo");
   if (!defined $repoout) {
     print STDERR "doesn't exist (or communication failure) :(\n";
     exit 2;


### PR DESCRIPTION
So apparently this bug has been around for ages, but was never triggered because so far everybody had had dw-nonfree forked as well as dw-free. In the case where dw-nonfree hasn't been forked, this would incorrectly state that it existed.

Thanks to exor674 for finding this!