### PR TITLE
Delete old checkout-skel script

### DIFF
--- a/sbin/checkout-skel
+++ b/sbin/checkout-skel
@@ -1,8 +1,0 @@
-#!/bin/bash
-export LJHOME=/dreamhack/opt/dhroot
-wget -O $LJHOME/cvs/multicvs.conf http://hg.dwscoalition.org/dw-free/raw-file/tip/cvs/multicvs.conf
-wget -O $LJHOME/bin/cvsreport.pl http://hg.dwscoalition.org/dw-free/raw-file/tip/bin/cvsreport.pl
-wget -O $LJHOME/bin/vcv http://hg.dwscoalition.org/dw-free/raw-file/tip/bin/vcv
-chmod ugo+x $LJHOME/bin/cvsreport.pl $LJHOME/bin/vcv
-$LJHOME/bin/cvsreport.pl --checkout
-hg -R $LJHOME/cvs/dw-free up -C null


### PR DESCRIPTION
This script was only needed back in the pre-GitHub days. Nowadays it's not used at all, so we can delete it!