### PR TITLE
Dreamhack Apache upgrade changes

### DIFF
--- a/sbin/dh-newuser
+++ b/sbin/dh-newuser
@@ -298,7 +298,7 @@ ServerRoot $UHOME/apache
 ServerName $USERNAME.$DOMAIN
 
 PidFile etc/httpd.pid
-LockFile etc/accept.lock
+Mutex file:etc default
 Timeout 30
 KeepAlive Off
 
@@ -321,7 +321,7 @@ SendBufferSize 163840
 
 DocumentRoot $LJHOME/htdocs
 <Directory "$LJHOME/htdocs">
-    Options -Indexes FollowSymLinks MultiViews
+    Options FollowSymLinks MultiViews
     AllowOverride All
 </Directory>
 
@@ -335,6 +335,9 @@ PerlRequire  $LJHOME/cgi-bin/modperl.pl
 LoadModule mime_module /usr/lib/apache2/modules/mod_mime.so
 TypesConfig /etc/mime.types
 
+Include /etc/apache2/mods-available/mpm_prefork.load
+Include /etc/apache2/mods-available/mpm_prefork.conf
+Include /etc/apache2/mods-available/authz_core.load
 HTTPDCONF
 
 echo chowning to correct user:group...

--- a/setup/apache/sites/default
+++ b/setup/apache/sites/default
@@ -10,7 +10,7 @@ NameVirtualHost *:8000
 		AllowOverride None
 	</Directory>
 	<Directory /dreamhack/www/>
-		Options Indexes FollowSymLinks MultiViews +Includes
+		Options Indexes FollowSymLinks MultiViews Includes
 		AllowOverride None
 		DirectoryIndex index.shtml
 		Order allow,deny

--- a/setup/apache/sites/docs
+++ b/setup/apache/sites/docs
@@ -9,7 +9,7 @@
 		AllowOverride None
 	</Directory>
 	<Directory /dreamhack/www/dev/docs/>
-		Options Indexes FollowSymLinks MultiViews +Includes
+		Options Indexes FollowSymLinks MultiViews Includes
 		AllowOverride None
 		DirectoryIndex index.html
 		Order allow,deny


### PR DESCRIPTION
The Dreamhack machine was upgraded to Trusty Tahr. These changes allow new Dreamhacks to work under Apache 2.4, included in Trusty Tahr.

Commit 6117b5b is already live on the Dreamhack machine; the other commit is not.