### PR TITLE
Use a single config file for new Dreamhacks

### DIFF
--- a/etc/apache/httpd.conf
+++ b/etc/apache/httpd.conf
@@ -1,0 +1,44 @@
+ServerRoot ${DREAMHACK_DIR}/apache
+ServerName ${DREAMHACK_USER}.hack.dreamwidth.net
+
+PidFile etc/httpd.pid
+Mutex file:etc default
+Timeout 30
+KeepAlive Off
+
+LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-agent}i\"" combined
+CustomLog logs/access_log combined
+ErrorLog logs/error_log
+
+Listen 127.0.0.1:${DREAMHACK_PORT}
+User ${DREAMHACK_SSHNAME}
+Group dreamhack
+
+MinSpareServers 1
+MaxSpareServers 2
+StartServers 2
+MaxClients 2
+MaxRequestsPerChild 100
+
+UseCanonicalName off
+SendBufferSize 163840
+
+DocumentRoot ${DREAMHACK_DIR}/dw/htdocs
+<Directory "${DREAMHACK_DIR}/dw/htdocs">
+    Options FollowSymLinks MultiViews
+    AllowOverride All
+</Directory>
+
+LoadModule apreq_module /usr/lib/apache2/modules/mod_apreq2.so
+LoadModule perl_module /usr/lib/apache2/modules/mod_perl.so
+LoadModule dir_module /usr/lib/apache2/modules/mod_dir.so
+
+PerlSetEnv   LJHOME ${DREAMHACK_DIR}/dw
+PerlRequire  ${DREAMHACK_DIR}/dw/cgi-bin/modperl.pl
+
+LoadModule mime_module /usr/lib/apache2/modules/mod_mime.so
+TypesConfig /etc/mime.types
+
+Include /etc/apache2/mods-available/mpm_prefork.load
+Include /etc/apache2/mods-available/mpm_prefork.conf
+Include /etc/apache2/mods-available/authz_core.load

--- a/sbin/dh-newuser
+++ b/sbin/dh-newuser
@@ -292,53 +292,13 @@ echo Copying home directory...
 cp -a $SKELDIR $UHOME
 echo Creating a .forward...
 echo $EMAIL > $UHOME/.forward    # any mail sent to this account will go to the email address in .forward.
-echo Creating custom httpd.conf...
-cat > $UHOME/apache/conf/httpd.conf <<HTTPDCONF
-ServerRoot $UHOME/apache
-ServerName $USERNAME.$DOMAIN
-
-PidFile etc/httpd.pid
-Mutex file:etc default
-Timeout 30
-KeepAlive Off
-
-LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-agent}i\"" combined
-CustomLog logs/access_log combined
-ErrorLog logs/error_log
-
-Listen $LISTENIP:$PORT
-User $UNIXUSER
-Group $DHGROUP
-
-MinSpareServers 1
-MaxSpareServers 2
-StartServers 2
-MaxClients 2
-MaxRequestsPerChild 100
-
-UseCanonicalName off
-SendBufferSize 163840
-
-DocumentRoot $LJHOME/htdocs
-<Directory "$LJHOME/htdocs">
-    Options FollowSymLinks MultiViews
-    AllowOverride All
-</Directory>
-
-LoadModule apreq_module /usr/lib/apache2/modules/mod_apreq2.so
-LoadModule perl_module /usr/lib/apache2/modules/mod_perl.so
-LoadModule dir_module /usr/lib/apache2/modules/mod_dir.so
-
-PerlSetEnv   LJHOME $LJHOME
-PerlRequire  $LJHOME/cgi-bin/modperl.pl
-
-LoadModule mime_module /usr/lib/apache2/modules/mod_mime.so
-TypesConfig /etc/mime.types
-
-Include /etc/apache2/mods-available/mpm_prefork.load
-Include /etc/apache2/mods-available/mpm_prefork.conf
-Include /etc/apache2/mods-available/authz_core.load
-HTTPDCONF
+echo Creating custom envvars file...
+cat > $UHOME/apache/conf/envvars <<ENVVARS
+export DREAMHACK_USER="$USERNAME"
+export DREAMHACK_PORT="$PORT"
+export DREAMHACK_DIR="$UHOME"
+export DREAMHACK_SSHNAME="$UNIXUSER"
+ENVVARS
 
 echo chowning to correct user:group...
 chown -R $UNIXUSER:$DHGROUP $UHOME

--- a/var/skel/apache/conf/httpd.conf
+++ b/var/skel/apache/conf/httpd.conf
@@ -1,5 +1,5 @@
 # Local Apache changes may be made in this file, if desired. The
-# $HOME/apache/conf/envvars file defines user-specific environment variables
-# used in the main Apache config.
+# ~/apache/conf/envvars file defines user-specific environment variables used
+# in the main Apache config.
 
 Include /dreamhack/etc/apache/httpd.conf

--- a/var/skel/apache/conf/httpd.conf
+++ b/var/skel/apache/conf/httpd.conf
@@ -1,0 +1,5 @@
+# Local Apache changes may be made in this file, if desired. The
+# $HOME/apache/conf/envvars file defines user-specific environment variables
+# used in the main Apache config.
+
+Include /dreamhack/etc/apache/httpd.conf

--- a/var/skel/bin/start-apache
+++ b/var/skel/bin/start-apache
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+source $HOME/apache/conf/envvars
 /usr/sbin/apache2ctl -f ~/apache/conf/httpd.conf -k start
 sleep 3
 ERROR=0

--- a/var/skel/bin/stop-apache
+++ b/var/skel/bin/stop-apache
@@ -1,3 +1,4 @@
 #!/bin/bash
 
+source $HOME/apache/conf/envvars
 /usr/sbin/apache2ctl -f ~/apache/conf/httpd.conf -k stop


### PR DESCRIPTION
Very few people change the default Apache config, and being able to modify it system-wide is helpful. Local changes are still permitted via the user's httpd.conf, but most changes will be able to be made globally now.

I haven't really been able to test this patch (I'll rebuild the dev-hack machine soon in order to allow me to do that - currently differences between the installed Ubuntu and the live machine's Ubuntu mean that it doesn't work properly on the dev-hack machine), but I have tested the components on the live machine with a test user and the changes seem to work fine.

I'll update people's configs as necessary after this has been pushed.