### PR TITLE
Use killall(1) instead of skill(1)

### DIFF
--- a/lib/bin/cron/maintain-dreamhacks
+++ b/lib/bin/cron/maintain-dreamhacks
@@ -188,7 +188,7 @@ MESSAGE
       # 2. password
       passwd($username, "!");
       # 3. kill kill kill
-      system("skill -KILL -u $username");
+      system("/usr/bin/killall", "-KILL", "-u", "$username");
 
       # delete everything
       foreach my $port (@{$userinfo->{'ports'}}) {
@@ -631,7 +631,7 @@ MESSAGE
 
       # kill with extreme prejudice
       passwd($username, "!");   # stop them from logging back in again for now
-      system("skill -KILL -u $username");
+      system("/usr/bin/killall", "-KILL", "-u", "$username");
 
       my $error = 0;
 

--- a/lib/bin/cron/maintain-dreamhacks
+++ b/lib/bin/cron/maintain-dreamhacks
@@ -188,7 +188,7 @@ MESSAGE
       # 2. password
       passwd($username, "!");
       # 3. kill kill kill
-      system("/usr/bin/killall", "-KILL", "-u", "$username");
+      system("/usr/bin/killall", "-KILL", "-u", $username);
 
       # delete everything
       foreach my $port (@{$userinfo->{'ports'}}) {
@@ -631,7 +631,7 @@ MESSAGE
 
       # kill with extreme prejudice
       passwd($username, "!");   # stop them from logging back in again for now
-      system("/usr/bin/killall", "-KILL", "-u", "$username");
+      system("/usr/bin/killall", "-KILL", "-u", $username);
 
       my $error = 0;
 

--- a/lib/bin/cron/remake-daily
+++ b/lib/bin/cron/remake-daily
@@ -20,7 +20,7 @@ else
   ps u -u dh-daily   # a way to see if the previous one worked
   echo "Stopping Apache... (ignore the error you get first thing in the delete-user process)"
   su -lc "stop-apache" dh-daily
-  skill -KILL -u dh-daily
+  /usr/bin/killall -KILL -u dh-daily
   /dreamhack/sbin/dh-deluser daily 7000
 fi
 


### PR DESCRIPTION
This use of skill(1) doesn't work on Trusty Tahr any more, it seems, and the manpage describes it as "obsolete and unportable". As such, let's use killall instead.

While we're at it, use the full path to killall and the multiple-parameter form of system().