### PR TITLE
Update stop-dreamhacks initscript for new config

### DIFF
--- a/etc/apache/safe-stop.conf
+++ b/etc/apache/safe-stop.conf
@@ -1,0 +1,11 @@
+# This small config file allows us to safely stop Apache instances as root
+
+ServerRoot ${DREAMHACK_DIR}/apache
+# this ServerName is just to stop the warning message
+ServerName stop
+
+PidFile etc/httpd.pid
+Mutex file:etc default
+
+Include /etc/apache2/mods-available/mpm_prefork.load
+Include /etc/apache2/mods-available/mpm_prefork.conf

--- a/lib/bin/all-home-dirs
+++ b/lib/bin/all-home-dirs
@@ -1,0 +1,9 @@
+#!/usr/bin/perl
+
+require '/dreamhack/lib/dreamhacks-db.pl';
+
+my $sth = $dbh->prepare("SELECT `homedir` FROM `users`");
+$sth->execute();
+while (my ($dir) = $sth->fetchrow_array()) {
+  print "$dir\n";
+}

--- a/setup/initscripts/stop-dreamhacks-initscript
+++ b/setup/initscripts/stop-dreamhacks-initscript
@@ -6,11 +6,12 @@ case $1 in
     exit 3
   ;;
   stop)
-    for dreamhack in `/dreamhack/lib/bin/all-apache-dirs`; do
-      if [ -f "$dreamhack/etc/httpd.pid" ]; then
+    for dreamhack in `/dreamhack/lib/bin/all-home-dirs`; do
+      if [ -f "$dreamhack/apache/etc/httpd.pid" ]; then
         echo "Stopping Dreamhack at $dreamhack..."
-        echo "  /usr/sbin/apache2ctl -f $dreamhack/conf/httpd.conf -k stop"
-        /usr/sbin/apache2ctl -f $dreamhack/conf/httpd.conf -k stop
+        DREAMHACK_DIR="$dreamhack"
+        export DREAMHACK_DIR
+        /usr/sbin/apache2ctl -f /dreamhack/etc/apache/safe-stop.conf -k stop   # uses $DREAMHACK_DIR to know which Apache to stop
         sleep 1
       fi
     done


### PR DESCRIPTION
Since we're now using a global Apache config, the old-style `stop-dreamhacks` initscript won't work. Fix it so it does and so we can safely stop Dreamhacks as root without having to source somebody's `envvars` file.