### PR TITLE
Fix reinstaller for config file location

### DIFF
--- a/sbin/dh-newuser
+++ b/sbin/dh-newuser
@@ -430,8 +430,28 @@ su -lc "
   mkdir -p ext/local/etc
   echo 'highest' > ext/local/.dir_scope
 
-  cp -a $LJHOME/doc/config-local.pl.txt $LJHOME/ext/local/etc/config-local.pl
-  cp -a $LJHOME/doc/config-private.pl.txt $LJHOME/ext/local/etc/config-private.pl
+  # we can't make any changes to these files or they'll show up in 'git status', so we can't move them.
+  cp -a $LJHOME/etc/config-local.pl $LJHOME/ext/local/etc/config-local.pl
+  cp -a $LJHOME/etc/config-private.pl $LJHOME/ext/local/etc/config-private.pl
+
+  # put a README in place so that people will know what to do
+  cat > $LJHOME/etc/README.txt <<README
+
+Please note that changes to the files in this directory might not take effect!
+
+This directory hosts the default configuration files from the 'dw-free' Git
+repository, and on a Dreamhack these files should not be edited unless you are
+working on an issue that requires a change to the default configuration files.
+To change the configuration of your Dreamhack, the correct configuration files
+to modify are located in:
+  \$LJHOME/ext/local/etc/
+
+The files in the above directory take precedence over the files in \$LJHOME/etc/,
+and will never be overwritten. If you wish to modify a file in this directory
+and it doesn't exist in \$LJHOME/ext/local/etc/, copy it there first, and then
+modify the copy.
+
+README
   chmod go-rwx $LJHOME/ext/local/etc/config-private.pl
 " $UNIXUSER
 


### PR DESCRIPTION
The move of the default configuration files from `doc/` to `etc/` break the installer, so this fixes the issue. It also adds a `README.txt` file on install that explains that changes made to that directory might not take effect.

No other changes are required as none of the other config changes clash with `lib/bin/do-config-stuff`.