### PR TITLE
Don't do double-interpolation when creating README

### DIFF
--- a/sbin/dh-newuser
+++ b/sbin/dh-newuser
@@ -435,7 +435,7 @@ su -lc "
   cp -a $LJHOME/etc/config-private.pl $LJHOME/ext/local/etc/config-private.pl
 
   # put a README in place so that people will know what to do
-  cat > $LJHOME/etc/README.txt <<README
+  cat > $LJHOME/etc/README.txt <<'README'
 
 Please note that changes to the files in this directory might not take effect!
 


### PR DESCRIPTION
I forgot that the inner bash shell would also interpolate these, which makes the file end up with nothing where I wanted a raw "$LJHOME".