### PR TITLE
Fix code tour generator to work with UTF-8

### DIFF
--- a/lib/bin/codetour.py
+++ b/lib/bin/codetour.py
@@ -142,7 +142,7 @@ def print_codetour(issues):
     text.append("%d total issues resolved" % len(issues))
     text.append("Contributors: %s" % ', '.join(contributors_list))
 
-    print '\n'.join(text)
+    print '\n'.join(text).encode('utf-8')
 
 
 if __name__ == '__main__':

--- a/www/dev/codetour/index.cgi
+++ b/www/dev/codetour/index.cgi
@@ -1,12 +1,13 @@
 #!/usr/bin/perl
 
 use CGI qw(:standard);
-print header;
+print header("text/html; charset=UTF-8");
 
 use HTML::Entities;
 use LWP::Simple qw(get);
 use Text::CSV::Slurp;
 use IPC::Run3;
+use Encode;
 
 my $python = "/usr/bin/python";
 my $codetourgenerator = "/dreamhack/lib/bin/codetour.py";
@@ -128,6 +129,7 @@ else {
   run3([$python, $codetourgenerator, @args], undef, \$output, \$errors);
   my $errno = $?;
   if ($errno == 0) {
+    $output = decode("utf-8", $output);
     my $doutput = encode_entities($output);
     print <<HTML;
 <html>


### PR DESCRIPTION
The generator broke on UTF-8 characters in issue subjects that couldn't be converted to ASCII, which was the case for dreamwidth/dw-free#1598 today due to the ellipsis ("…"). This code change fixes it!