### PR TITLE
Add more delay to start-apache

### DIFF
--- a/var/skel/bin/start-apache
+++ b/var/skel/bin/start-apache
@@ -2,16 +2,25 @@
 
 source $HOME/apache/conf/envvars
 /usr/sbin/apache2ctl -f ~/apache/conf/httpd.conf -k start
-sleep 3
-ERROR=0
 PIDFILE=~/apache/etc/httpd.pid
-if [ ! -f $PIDFILE ]; then
-  ERROR=1;
-elif kill -0 `cat ~/apache/etc/httpd.pid`; then
-  echo "Apache started successfully!"
-else ERROR=1; fi
+
+echo -n "Waiting for Apache to start"
+for i in {1..6}; do
+  sleep 1
+  echo -n "."
+  ERROR=0
+  if [ ! -f $PIDFILE ]; then
+    ERROR=1;
+  elif kill -0 `cat ~/apache/etc/httpd.pid`; then
+    echo
+    echo "Apache started successfully!"
+  else ERROR=1; fi
+
+  if [[ "$ERROR" == "0" ]]; then break; fi
+done
 
 if [[ "$ERROR" == "1" ]]; then
+  echo
   echo "Apache failed to start, please review the error_log. (last 5 lines of the log follow:)"
   tail -n5 ~/apache/logs/error_log
 fi


### PR DESCRIPTION
Previously start-apache only paused for 3 seconds while waiting for Apache to start. This change means that new users will get a new start-apache implementation which pauses for up to 6 seconds.

This change has already been rolled out for existing users (about a month ago), and I meant to put made this change for new users at the same time.