### PR TITLE
update code tour generator to use main instead of develop

### DIFF
--- a/www/dev/codetour/index.cgi
+++ b/www/dev/codetour/index.cgi
@@ -88,7 +88,7 @@ if (!defined $dates) {
 <p><small>The default value of the 'from' date is determined by the latest commit in the '<b>code-tour</b>' branch in the local copy of the dreamwidth repository, which is refreshed weekly.</small></p>
 
 <p><small>As a guide to how up-to-date the local copy of the repository is, the last commit on 'main' according to this repository was made on <a href="https://github.com/dreamwidth/dreamwidth/commit/$refreshcommit">$refreshdate</a>. The closer this date is to today, the better.</small></p>
-<p>This script uses <span style='white-space: nowrap;'><a href='https://afuna.dreamwidth.org/profile'><img src='https://s.dreamwidth.org/img/silk/identity/user.png' alt='[personal profile] ' width='17' height='17' style='vertical-align: text-bottom; border: 0; padding-right: 1px;' /></a><a href='https://afuna.dreamwidth.org/'><b>afuna</b></a></span>'s code tour generator, programmed in Python.</p>
+<p>This script uses <span style='white-space: nowrap;'><a href='https://afuna.dreamwidth.org/profile'><img src='https://www.dreamwidth.org/img/silk/identity/user.png' alt='[personal profile] ' width='17' height='17' style='vertical-align: text-bottom; border: 0; padding-right: 1px;' /></a><a href='https://afuna.dreamwidth.org/'><b>afuna</b></a></span>'s code tour generator, programmed in Python.</p>
 </body>
 </html>
 HTML
@@ -158,7 +158,7 @@ HTML
 <hr>
 <p>The Python generator returned an error:</p>
 <pre>$derrors</pre>
-<p>You may want to try again, or else <a href="https://github.com/dreamwidth/dreamwidth/issues">manually do the code tour</a>. Also, poke <span style='white-space: nowrap;'><a href='https://mark.dreamwidth.org/profile'><img src='https://s.dreamwidth.org/img/silk/identity/user.png' alt='[personal profile] ' width='17' height='17' style='vertical-align: text-bottom; border: 0; padding-right: 1px;' /></a><a href='https://mark.dreamwidth.org/'><b>mark</b></a></span> about this.</p>
+<p>You may want to try again, or else <a href="https://github.com/dreamwidth/dreamwidth/issues">manually do the code tour</a>. Also, poke <span style='white-space: nowrap;'><a href='https://mark.dreamwidth.org/profile'><img src='https://www.dreamwidth.org/img/silk/identity/user.png' alt='[personal profile] ' width='17' height='17' style='vertical-align: text-bottom; border: 0; padding-right: 1px;' /></a><a href='https://mark.dreamwidth.org/'><b>mark</b></a></span> about this.</p>
 </body>
 </html>
 HTML
@@ -224,7 +224,7 @@ sub error {
 <p><input type="submit" value="Generate"></p>
 </form>
 <p><small>The default value of the 'from' date is determined by the '<b>code-tour</b>' tag in the local dreamwidth repository, which is refreshed weekly; it was last refreshed at $refreshdate</b>.</small></p>
-<p>This script uses <span style='white-space: nowrap;'><a href='https://afuna.dreamwidth.org/profile'><img src='https://s.dreamwidth.org/img/silk/identity/user.png' alt='[personal profile] ' width='17' height='17' style='vertical-align: text-bottom; border: 0; padding-right: 1px;' /></a><a href='https://afuna.dreamwidth.org/'><b>afuna</b></a></span>'s code tour generator, programmed in Python.</p>
+<p>This script uses <span style='white-space: nowrap;'><a href='https://afuna.dreamwidth.org/profile'><img src='https://www.dreamwidth.org/img/silk/identity/user.png' alt='[personal profile] ' width='17' height='17' style='vertical-align: text-bottom; border: 0; padding-right: 1px;' /></a><a href='https://afuna.dreamwidth.org/'><b>afuna</b></a></span>'s code tour generator, programmed in Python.</p>
 </body>
 </html>
 HTML

--- a/www/dev/codetour/index.cgi
+++ b/www/dev/codetour/index.cgi
@@ -17,19 +17,19 @@ my $fromdate = param("fromdate");
 my $todate = param("todate");
 
 my $git = '/usr/bin/git --git-dir="/dreamhack/opt/dhroot/.git" --work-tree="/dreamhack/opt/dhroot"';
-my ($refreshcommit, $refreshdate) = split(/,/, `$git show -s --pretty=format:"%H,%ci" develop`);
+my ($refreshcommit, $refreshdate) = split(/,/, `$git show -s --pretty=format:"%H,%ci" main`);
 my $codetourrev = `$git rev-parse origin/code-tour`;
-my @revs = split(/\n/, `$git log --first-parent --pretty=format:"%H" $codetourrev^..develop`);
-# check to see that $codetourrev is the last rev in @revs; if not, that means the 'code-tour' branch isn't on a 'develop' merge and things might be a bit weird.
+my @revs = split(/\n/, `$git log --first-parent --pretty=format:"%H" $codetourrev^..main`);
+# check to see that $codetourrev is the last rev in @revs; if not, that means the 'code-tour' branch isn't on a 'main' merge and things might be a bit weird.
 my $warning = "";
 if ($revs[$#revs] eq $codetourrev) {
-  $warning = "<p><strong>Warning:</strong> The 'code-tour' branch doesn't seem to be on a commit or merge made directly to 'develop'. You may want to enter the date of the last code tour manually.</p>";
+  $warning = "<p><strong>Warning:</strong> The 'code-tour' branch doesn't seem to be on a commit or merge made directly to 'main'. You may want to enter the date of the last code tour manually.</p>";
 }
 
 my $ctdateunix = `$git show -s --pretty=format:"%ct" origin/code-tour`;
 my (undef, undef, undef, $ctday, $ctmonth, $ctyear) = gmtime($ctdateunix);
 my $codetourdate = sprintf("%d-%02d-%02d", ($ctyear + 1900), ($ctmonth + 1), $ctday);
-# git log --first-parent --oneline code-tour^..develop
+# git log --first-parent --oneline code-tour^..main
 if (!defined $dates) {
   print <<HTML;
 <html>
@@ -87,7 +87,7 @@ if (!defined $dates) {
 </form>
 <p><small>The default value of the 'from' date is determined by the latest commit in the '<b>code-tour</b>' branch in the local copy of the dreamwidth repository, which is refreshed weekly.</small></p>
 
-<p><small>As a guide to how up-to-date the local copy of the repository is, the last commit on 'develop' according to this repository was made on <a href="https://github.com/dreamwidth/dreamwidth/commit/$refreshcommit">$refreshdate</a>. The closer this date is to today, the better.</small></p>
+<p><small>As a guide to how up-to-date the local copy of the repository is, the last commit on 'main' according to this repository was made on <a href="https://github.com/dreamwidth/dreamwidth/commit/$refreshcommit">$refreshdate</a>. The closer this date is to today, the better.</small></p>
 <p>This script uses <span style='white-space: nowrap;'><a href='https://afuna.dreamwidth.org/profile'><img src='https://s.dreamwidth.org/img/silk/identity/user.png' alt='[personal profile] ' width='17' height='17' style='vertical-align: text-bottom; border: 0; padding-right: 1px;' /></a><a href='https://afuna.dreamwidth.org/'><b>afuna</b></a></span>'s code tour generator, programmed in Python.</p>
 </body>
 </html>


### PR DESCRIPTION
It was still looking at develop after all this time... although it seemed not to really matter for tour generation purposes, as long as the code-tour branch was where it was expected to be. But the comparison was useless since the develop branch has been stale since 2019. @alierak updated the checked out code on the box as well.

This also updates the userhead links not to use s.dreamwidth.org, which doesn't seem to be a thing at the moment.